### PR TITLE
Fixed callback0; no longer immediately invokes

### DIFF
--- a/src/Data/Foreign/Callback.purs
+++ b/src/Data/Foreign/Callback.purs
@@ -1,4 +1,4 @@
-module Data.Foreign.Callback 
+module Data.Foreign.Callback
 
 where
 
@@ -18,79 +18,79 @@ foreign import data Callback10:: * -> * -> * -> * -> * -> * -> * -> * -> * -> * 
 
 foreign import callback0 """
   var callback0 = function(eff) {
-    return eff();
-  };""" 
-  :: forall z r. Eff z r 
+    return function(){ return eff(); };
+  };"""
+  :: forall z r. Eff z r
   -> Callback0 r
 
 foreign import callback1 """
   var callback1 = function(fn) {
     return function(a) { return fn(a)(); };
-  };""" 
-  :: forall z r a. (a -> Eff z r) 
+  };"""
+  :: forall z r a. (a -> Eff z r)
   -> Callback1 a r
 
 foreign import callback2 """
   var callback2 = function(fn) {
     return function(a,b) { return fn(a)(b)(); };
-  };""" 
-  :: forall z r a b. (a -> b -> Eff z r) 
+  };"""
+  :: forall z r a b. (a -> b -> Eff z r)
   -> Callback2 a b r
 
 foreign import callback3 """
   var callback3 = function(fn) {
     return function(a,b,c) { return fn(a)(b)(c)(); };
-  };""" 
-  :: forall z r a b c. (a -> b -> c -> Eff z r) 
+  };"""
+  :: forall z r a b c. (a -> b -> c -> Eff z r)
   -> Callback3 a b c r
 
 foreign import callback4 """
   var callback4 = function(fn) {
     return function(a,b,c,d) { return fn(a)(b)(c)(d)(); };
-  };""" 
-  :: forall z r a b c d. (a -> b -> c -> d -> Eff z r) 
+  };"""
+  :: forall z r a b c d. (a -> b -> c -> d -> Eff z r)
   -> Callback4 a b c d r
 
 foreign import callback5 """
   var callback5 = function(fn) {
     return function(a,b,c,d,e) { return fn(a)(b)(c)(d)(e)(); };
-  };""" 
-  :: forall z r a b c d e. (a -> b -> c -> d -> e -> Eff z r) 
+  };"""
+  :: forall z r a b c d e. (a -> b -> c -> d -> e -> Eff z r)
   -> Callback5 a b c d e r
 
 foreign import callback6 """
   var callback6 = function(fn) {
     return function(a,b,c,d,e,f) { return fn(a)(b)(c)(d)(e)(f)(); };
-  };""" 
-  :: forall z r a b c d e f. (a -> b -> c -> d -> e -> f -> Eff z r) 
+  };"""
+  :: forall z r a b c d e f. (a -> b -> c -> d -> e -> f -> Eff z r)
   -> Callback6 a b c d e f r
 
 foreign import callback7 """
   var callback7 = function(fn) {
     return function(a,b,c,d,e,f,g) { return fn(a)(b)(c)(d)(e)(f)(g)(); };
-  };""" 
-  :: forall z r a b c d e f g. (a -> b -> c -> d -> e -> f -> g -> Eff z r) 
+  };"""
+  :: forall z r a b c d e f g. (a -> b -> c -> d -> e -> f -> g -> Eff z r)
   -> Callback7 a b c d e f g r
 
 foreign import callback8 """
   var callback8 = function(fn) {
     return function(a,b,c,d,e,f,g,h) { return fn(a)(b)(c)(d)(e)(f)(g)(h)(); };
-  };""" 
-  :: forall z r a b c d e f g h. (a -> b -> c -> d -> e -> f -> g -> h -> Eff z r) 
-  -> Callback8 a b c d e f g h r 
+  };"""
+  :: forall z r a b c d e f g h. (a -> b -> c -> d -> e -> f -> g -> h -> Eff z r)
+  -> Callback8 a b c d e f g h r
 
 foreign import callback9 """
   var callback9 = function(fn) {
     return function(a,b,c,d,e,f,g,h,i) { return fn(a)(b)(c)(d)(e)(f)(g)(h)(i)(); };
-  };""" 
-  :: forall z r a b c d e f g h i. (a -> b -> c -> d -> e -> f -> g -> h -> i -> Eff z r) 
+  };"""
+  :: forall z r a b c d e f g h i. (a -> b -> c -> d -> e -> f -> g -> h -> i -> Eff z r)
   -> Callback9 a b c d e f g h i r
 
 foreign import callback10 """
   var callback10 = function(fn) {
     return function(a,b,c,d,e,f,g,h,i,j) { return fn(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(); };
-  };""" 
-  :: forall z r a b c d e f g h i j. (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> Eff z r) 
+  };"""
+  :: forall z r a b c d e f g h i j. (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> Eff z r)
   -> Callback10 a b c d e f g h i j r
 
 callback1_  eff = callback1  $ \a -> eff
@@ -103,5 +103,3 @@ callback7_  eff = callback7  $ \a b c d e f g -> eff
 callback8_  eff = callback8  $ \a b c d e f g h -> eff
 callback9_  eff = callback9  $ \a b c d e f g h i -> eff
 callback10_ eff = callback10 $ \a b c d e f g h i j -> eff
-
-


### PR DESCRIPTION
callback0 automatically invokes the Eff it's passed when instantiated in pure code. This fix should correct that.
The following small snippet demonstrates the problem:

``` javascript
module Main where

import Debug.Trace
import Control.Monad.Eff

foreign import data Callback0 :: * -> *
foreign import callback0 """
  var callback0 = function(eff) {
    return eff();
  };""" 
  :: forall z r. Eff z r 
  -> Callback0 r


main = do
    trace "Hello, World!"
    let a = callback0 (trace "Don't print me")
    trace "Goodbye, World!"
```

(I ran this at http://try.purescript.org/ )

My editor apparently decided to change the whitespace slightly for whatever reason as well.
